### PR TITLE
Fix dynamic.c segmentation fault

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -27,7 +27,7 @@ void compile_and_run(){
         return;
     }
 
-    void *handle = dlopen("fn.so", RTLD_LAZY);
+    void *handle = dlopen("./fn.so", RTLD_LAZY);
     if (!handle) printf("Failed to load fn.so: %s\n", dlerror());
 
     typedef double (*fn_type)(double);


### PR DESCRIPTION
Make dlopen() use cwd.

Without this fix the program will get a segmentation fault, as
dlopen() will return NULL, and dlerror() diagnoses:

    Failed to load fn.so: fn.so: cannot open shared object file: No such file or
    directory

man dlopen says:

    If filename contains a slash ("/"), then it is interpreted as a (relative or
    absolute) pathname (**what we want**). Otherwise, the dynamic linker
    searches for the object as follows… (*lists several options that don't 
    search for the cwd unless you set up env vars*)