### PR TITLE
Improve make_bit example

### DIFF
--- a/auto.conf
+++ b/auto.conf
@@ -19,10 +19,8 @@ sed -e 's/FULL-PACKAGE-NAME/hello/' \
     -e 's/VERSION/1/'   \
     -e 's|BUG-REPORT-ADDRESS|/dev/null|' \
     -e '10i\
-AM_INIT_AUTOMAKE' \
+AM_INIT_AUTOMAKE([foreign])' \
        < configure.scan > configure.ac
-
-touch NEWS README AUTHORS ChangeLog
 
 autoreconf -iv
 ./configure

--- a/make_bit
+++ b/make_bit
@@ -1,7 +1,6 @@
     push:
-        @if [ "x$(MSG)" = 'x' ] ; then \
-                echo "Usage: MSG='your message here.' make push"; fi
-        @test "x$(MSG)" != 'x'
+        @if [ -z "$(MSG)" ]; then \
+                echo "Usage: MSG='your message here.' make push"; false; fi
         git commit -a  -m "$(MSG)"
         git svn fetch
         git svn rebase


### PR DESCRIPTION
There are two points in this example I do not get:

 1. Why testing '[ "x$(MSG)" = 'x' ]', when there exists a direct way
    of testing whether 'MSG' is a string of zero length, namely
    '[ -z "$(MSG)" ]"?  Do I miss something here?

 2. Why testing the 'MSG' variable twice, if the 'push' target could
     be aborted in the first 'if' statement by adding the 'false'
     command?