### PR TITLE
rss feed now comes from a https:// url

### DIFF
--- a/nyt_feed.c
+++ b/nyt_feed.c
@@ -42,7 +42,7 @@ installed for this to work.
 
 //These have in-line Doxygen documentation. The < points to the prior text
 //being documented.
-char *rss_url = "http://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml";
+char *rss_url = "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml";
                                       /**< The URL for an NYT RSS. */
 char *rssfile = "nytimes_feeds.rss";  /**< A local file to write the RSS to.*/
 char *outfile = "now.html";       /**< The output file to open in your browser.*/


### PR DESCRIPTION
Modern websites only use the https protocol, not http, for your protection.

The code in the book no longer works: 

- You get an "file is empty" error, 
- the .rss file generated is 0 bytes long, and 
- no 'now.html' file is generated.

This simple change (added an 's' to the url) fixes it.